### PR TITLE
OAS MP 2024 0402 JAN CPU with terraform version update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,4 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## OAS 2025 0101 JAN Updates
-
-## OAS 2024 0401 JAN Updates
-
-## OAS 2024 0301
-
-## OAS 2024 0201
+## OAS 2024 0402 JAN Updates

--- a/terraform/computeinstance/cloud_init/cloudinit.template.yaml
+++ b/terraform/computeinstance/cloud_init/cloudinit.template.yaml
@@ -1,9 +1,5 @@
 
 output: {all: '| tee -a /var/log/oas_cloudinit.log'}
-
-logcfg: |
-  [formatters]
-  format=%(levelname)s %(asctime)s: %(message)s
   
 write_files:
   - path: /tmp/oas-scripts/generate_biconfig.sh

--- a/terraform/oci_images.tf
+++ b/terraform/oci_images.tf
@@ -6,7 +6,7 @@ variable "marketplace_source_images" {
   }))
   default = {
     main_mktpl_image = {
-      ocid = "ocid1.image.oc1..aaaaaaaa6dldo2smeo5xd3glmpazvet7l2eqsriv4h2pqq5ywykrin64qylq"
+      ocid = "ocid1.image.oc1..aaaaaaaa4ytlianwifriuodywp4qk2ulvulxui7sun7qajuy7fa3kse6ot6a"
       is_pricing_associated = true
       compatible_shapes = ["VM.Standard2.1" , "VM.Standard2.16" , "VM.Standard2.2" , "VM.Standard2.24" , "VM.Standard2.4" , "VM.Standard2.8" , "VM.Standard.E3.Flex" , "VM.Standard.E4.Flex"]
     }

--- a/terraform/oci_images.tf.ucm
+++ b/terraform/oci_images.tf.ucm
@@ -6,7 +6,7 @@ variable "marketplace_source_images" {
   }))
   default = {
     main_mktpl_image = {
-      ocid = "ocid1.image.oc1..aaaaaaaafaqbrtwbcvmgfakqqx2jasadezzpypcar655f5mgvtaywvazwpua"
+      ocid = "ocid1.image.oc1..aaaaaaaawxi3oseck5i4ghw3ckd4aozdfzlcxauncwdqzwvp53bschlqzkxa"
       is_pricing_associated = true
       compatible_shapes = ["VM.Standard2.1" , "VM.Standard2.16" , "VM.Standard2.2" , "VM.Standard2.24" , "VM.Standard2.4" , "VM.Standard2.8" , "VM.Standard.E3.Flex" , "VM.Standard.E4.Flex"]
     }

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -3,5 +3,5 @@
 
 # Listing details for the Oracle Analytics Server custom image for Bring Your Own License.
 mp_OAS_listing_id="ocid1.appcataloglisting.oc1..aaaaaaaa4jfofm2dkaigvmlrssdhy47pf2obig6dgpdg7deesmn7b5lxzfyq"
-mp_OAS_listing_resource_version="2025_0101"
-mp_OAS_listing_image_resource_id="ocid1.image.oc1..aaaaaaaa6dldo2smeo5xd3glmpazvet7l2eqsriv4h2pqq5ywykrin64qylq"
+mp_OAS_listing_resource_version="2024_0401"
+mp_OAS_listing_image_resource_id="ocid1.image.oc1..aaaaaaaa4ytlianwifriuodywp4qk2ulvulxui7sun7qajuy7fa3kse6ot6a"

--- a/terraform/terraform.tfvars.ucm
+++ b/terraform/terraform.tfvars.ucm
@@ -1,7 +1,7 @@
 ## Copyright (c) 2021, Oracle and/or its affiliates.
 ## Licensed under the Universal Permissive License v1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-# Listing details for the Oracle Analytics Server custom image for Bring Your Own License.
+# Listing details for the Oracle Analytics Server custom image for Universal Content Management.
 mp_OAS_listing_id="ocid1.appcataloglisting.oc1..aaaaaaaawrehiz4hdfqnpr535fbbkknowmpra76fa4ozdzmtarodkpcsxika"
-mp_OAS_listing_resource_version="2025_0101"
-mp_OAS_listing_image_resource_id="ocid1.image.oc1..aaaaaaaafaqbrtwbcvmgfakqqx2jasadezzpypcar655f5mgvtaywvazwpua"
+mp_OAS_listing_resource_version="2024_0401"
+mp_OAS_listing_image_resource_id="ocid1.image.oc1..aaaaaaaawxi3oseck5i4ghw3ckd4aozdfzlcxauncwdqzwvp53bschlqzkxa"

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = "~> 0.12.0, < 0.13"
+  required_version = "~> 1.0, < 1.1"
 }


### PR DESCRIPTION
OAS MP 2024 0402 JAN CPU with terraform version update
Withdraw OAS MP 2024 0401, 0301 & 0201 since they will not work on ORM due to terraform version requirements